### PR TITLE
35-cache-with-limited-size

### DIFF
--- a/newsfeeds/api/tests.py
+++ b/newsfeeds/api/tests.py
@@ -3,6 +3,8 @@ from friendships.models import Friendship
 from rest_framework.test import APIClient
 from testing.testcases import TestCase
 from utils.paginations import EndlessPagination
+from django.conf import settings
+from newsfeeds.services import NewsFeedService
 
 
 NEWSFEEDS_URL = '/api/newsfeeds/'
@@ -154,5 +156,56 @@ class NewsFeedApiTests(TestCase):
         response = self.dongxie_client.get(NEWSFEEDS_URL)
         results = response.data['results']
         self.assertEqual(results[0]['tweet']['content'], 'content2')
+
+    def _paginate_to_get_newsfeeds(self, client):
+        # paginate until the end
+        response = client.get(NEWSFEEDS_URL)
+        results = response.data['results']
+        while response.data['has_next_page']:
+            created_at__lt = response.data['results'][-1]['created_at']
+            print(created_at__lt)
+            response = client.get(NEWSFEEDS_URL, {'created_at__lt': created_at__lt})
+            results.extend(response.data['results'])
+        return results
+
+    def test_redis_list_limit(self):
+        list_limit = settings.REDIS_LIST_LENGTH_LIMIT
+        page_size = EndlessPagination.page_size
+        users = [self.create_user('user{}'.format(i)) for i in range(5)]
+        newsfeeds = []
+        for i in range(list_limit + page_size):
+            tweet = self.create_tweet(user=users[i % 5], content='feed{}'.format(i))
+            feed = self.create_newsfeed(self.linghu, tweet)
+            newsfeeds.append(feed)
+        newsfeeds = newsfeeds[::-1]
+
+        # only ached list_limit objects
+        cached_newsfeeds = NewsFeedService.get_cached_newsfeeds(self.linghu.id)
+        self.assertEqual(len(cached_newsfeeds), list_limit)
+        queryset = NewsFeed.objects.filter(user=self.linghu)
+        self.assertEqual(queryset.count(), list_limit + page_size)
+
+        results = self._paginate_to_get_newsfeeds(self.linghu_client)
+        self.assertEqual(len(results), list_limit + page_size)
+        for i in range(list_limit + page_size):
+            self.assertEqual(newsfeeds[i].id, results[i]['id'])
+
+        # a followed user create a new tweet
+        self.create_friendship(self.linghu, self.dongxie)
+        new_tweet = self.create_tweet(self.dongxie, 'a new tweet')
+        NewsFeedService.fanout_to_followers(new_tweet)
+
+        def _test_newsfeeds_after_new_feed_pushed():
+            results = self._paginate_to_get_newsfeeds(self.linghu_client)
+            self.assertEqual(len(results), list_limit + page_size + 1)
+            self.assertEqual(results[0]['tweet']['id'], new_tweet.id)
+            for i in range(list_limit + page_size):
+                self.assertEqual(newsfeeds[i].id, results[i + 1]['id'])
+
+        _test_newsfeeds_after_new_feed_pushed()
+
+        # cache expired
+        self.clear_cache()
+        _test_newsfeeds_after_new_feed_pushed()
 
 

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -20,9 +20,12 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         return NewsFeedService.get_cached_newsfeeds(self.request.user.id)
 
     def list(self, request):
-        queryset = self.get_queryset()
-        page = self.paginate_queryset(queryset)
-
+        cached_newsfeeds = self.get_queryset()
+        page = self.paginator.paginate_cached_list(cached_newsfeeds, request)
+        # page 是 None 代表我现在请求的数据可能不在 cache 里，需要直接去 db 来获取
+        if page is None:
+            queryset = NewsFeed.objects.filter(user=request.user)
+            page = self.paginate_queryset(queryset)
         serializer = NewsFeedSerializer(
             page,
             context={'request': request},

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -8,6 +8,7 @@ from likes.models import Like
 from newsfeeds.models import NewsFeed
 from django.core.cache import caches
 from utils.redis_client import RedisClient
+from friendships.models import Friendship
 
 
 class TestCase(DjangoTestCase):
@@ -59,3 +60,6 @@ class TestCase(DjangoTestCase):
 
     def create_newsfeed(self, user, tweet):
         return NewsFeed.objects.create(user=user, tweet=tweet)
+
+    def create_friendship(self, from_user, to_user):
+        Friendship.objects.create(from_user=from_user, to_user=to_user)

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -23,10 +23,19 @@ class TweetViewSet(viewsets.GenericViewSet):
     @required_params(params=['user_id'])
     def list(self, request):
         user_id = request.query_params['user_id']
-        tweets = TweetService.get_cached_tweets(user_id=request.query_params['user_id'])
-        tweets = self.paginate_queryset(tweets)
+        cached_tweets = TweetService.get_cached_tweets(user_id)
+        page = self.paginator.paginate_cached_list(cached_tweets, request)
+        if page is None:
+            # 这句查询会被翻译为
+            # select * from twitter_tweets
+            # where user_id = xxx
+            # order by created_at desc
+            # 这句 sql 查询会用到 user 和 created_at 的联合索引
+            # 单纯的 user 索引是不够的
+            queryset = Tweet.objects.filter(user_id=user_id).order_by('-created_at')
+            page = self.paginate_queryset(queryset)
         serializer = TweetSerializer(
-            tweets,
+            page,
             context={'request': request},
             many=True,
         )

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -186,7 +186,7 @@ REDIS_HOST = '127.0.0.1'
 REDIS_PORT = 6379
 REDIS_DB = 0 if TESTING else 1
 REDIS_KEY_EXPIRE_TIME = 7 * 86400  # in seconds
-
+REDIS_LIST_LENGTH_LIMIT = 200 if not TESTING else 20
 
 try:
     from .local_settings import *

--- a/utils/paginations.py
+++ b/utils/paginations.py
@@ -1,10 +1,11 @@
 from rest_framework.pagination import BasePagination
 from rest_framework.response import Response
 from dateutil import parser
+from django.conf import settings
 
 
 class EndlessPagination(BasePagination):
-    page_size = 20
+    page_size = 20 if not settings.TESTING else 10
 
     def __init__(self):
         super(EndlessPagination, self).__init__()
@@ -66,6 +67,22 @@ class EndlessPagination(BasePagination):
         queryset = queryset.order_by('-created_at')[:self.page_size + 1]
         self.has_next_page = len(queryset) > self.page_size
         return queryset[:self.page_size]
+
+    def paginate_cached_list(self, cached_list, request):
+        paginated_list = self.paginate_ordered_list(cached_list, request)
+        # 如果是上翻页，抓最新数据。paginated_list 里是所有的最新的数据，直接返回
+        if 'created_at__gt' in request.query_params:
+            return paginated_list
+        # 如果是 下翻页，或者刷新那种
+        # 如果还有下一页，说明 cached_list 里的数据还没有取完，也直接返回
+        if self.has_next_page:
+            return paginated_list
+        # 如果 cached_list 的长度不足最大限制，说明 cached_list 里已经是所有数据了
+        if len(cached_list) < settings.REDIS_LIST_LENGTH_LIMIT:
+            return paginated_list
+        # 如果 cache 充满了 限制settings.REDIS_LIST_LENGTH_LIMIT，说明数据有可能在 db 里
+        # 如果进入这里，说明可能存在在数据库里没有 load 在 cache 里的数据，需要直接去数据库查询
+        return None
 
     def get_paginated_response(self, data):
         return Response({

--- a/utils/redis_helper.py
+++ b/utils/redis_helper.py
@@ -10,7 +10,10 @@ class RedisHelper:
         conn = RedisClient.get_connection()
 
         serialized_list = []
-        for obj in objects:
+        # 最多知 cache REDIS_LIST_LENGTH_LIMIT 那么多个 objects
+        # 超过这个限制的 objects，就去数据库里读取。一般这个限制会比较大，比如 200
+        # 因此翻页翻到 200 的用户访问量会比较少，从数据库读取也不是大问题
+        for obj in objects[:settings.REDIS_LIST_LENGTH_LIMIT]:
             serialized_data = DjangoModelSerializer.serialize(obj)
             serialized_list.append(serialized_data)
 
@@ -48,3 +51,4 @@ class RedisHelper:
             return
         serialized_data = DjangoModelSerializer.serialize(obj)
         conn.lpush(key, serialized_data)
+        conn.ltrim(key, 0, settings.REDIS_LIST_LENGTH_LIMIT - 1)


### PR DESCRIPTION
Only load 200 newsfeeds to cache, because users do not need to see that much newsfeeds. 